### PR TITLE
Add support for database logs

### DIFF
--- a/bin/run-joe-cool.sh
+++ b/bin/run-joe-cool.sh
@@ -1,14 +1,38 @@
 #!/bin/bash
+set -o errexit
+
 : ${LOGSTASH_ENDPOINT:?"Error: environment variable LOGSTASH_ENDPOINT should contain the Gentleman Jerry endpoint."}
 : ${LOGSTASH_CERTIFICATE:?"Error: environment variable LOGSTASH_CERTIFICATE should contain Gentleman Jerry's certificate."}
 : ${CONTAINERS_TO_MONITOR:?"Error: environment variable CONTAINERS_TO_MONITOR should contain a comma-separated list of container ids."}
-export TAIL_OPT=$([ -z "$READ_FROM_BEGINNING" ] && echo "-tail=true")
 
 if [ ! -d /tmp/dockerlogs ]; then
   echo "/tmp/dockerlogs should exist and contain Docker logs."
   exit 1
 fi
-erb logstash-forwarder.config.erb > logstash-forwarder/logstash-forwarder.config && \
-cd logstash-forwarder && \
-echo "$LOGSTASH_CERTIFICATE" > logstash.crt && \
+
+# We persist whether we sent all the logs via READ_FROM_BEGINNING into a file
+# (HAS_READ_FROM_BEGINNING). This ensures that if Joe Cool is restarted, we
+# don't re-send all the logs.
+
+HAS_READ_FROM_BEGINNING=/tmp/read-from-beginning
+
+TAIL_OPT="-tail=true"
+
+if [[ -n "$READ_FROM_BEGINNING" ]]; then
+  echo "READ_FROM_BEGINNING is TRUE"
+fi
+
+if [[ ! -f "$HAS_READ_FROM_BEGINNING" ]]; then
+  echo "FILE NOT PRESENT is TRUE"
+fi
+
+if [[ -n "$READ_FROM_BEGINNING" ]] && [[ ! -f "$HAS_READ_FROM_BEGINNING" ]]; then
+  touch "$HAS_READ_FROM_BEGINNING"
+  TAIL_OPT=""
+fi
+
+erb logstash-forwarder.config.erb > logstash-forwarder/logstash-forwarder.config
+cd logstash-forwarder
+echo "$LOGSTASH_CERTIFICATE" > logstash.crt
+
 exec ./logstash-forwarder -config logstash-forwarder.config -max-line-bytes=101376 $TAIL_OPT

--- a/templates/logstash-forwarder.config.erb
+++ b/templates/logstash-forwarder.config.erb
@@ -16,6 +16,7 @@
       "fields": {
         "service": "<%= ENV['SERVICE_NAME'] || '*' %>",
         "<%= layer %>": "<%= ENV['APP_NAME'] || ENV['DATABASE_NAME'] || '*' %>",
+        "<%= layer %>_id": "<%= ENV['APP_ID'] || ENV['DATABASE_ID'] || '*' %>",
         "source": "<%= layer %>",
         "layer": "<%= layer %>"
       }
@@ -29,6 +30,7 @@
       "fields": {
         "service": "<%= ENV['SERVICE_NAME'] || '*' %>",
         "<%= layer %>": "<%= ENV['APP_NAME'] || ENV['DATABASE_NAME'] || '*' %>",
+        "<%= layer %>_id": "<%= ENV['APP_ID'] || ENV['DATABASE_ID'] || '*' %>",
         "source": "aptible",
         "layer": "<%= layer %>"
       }

--- a/templates/logstash-forwarder.config.erb
+++ b/templates/logstash-forwarder.config.erb
@@ -1,3 +1,4 @@
+<% layer = ENV['APP_NAME'] ? 'app' : 'database' %>
 {
   "network": {
     "servers": [ "<%= ENV['LOGSTASH_ENDPOINT'] %>" ],
@@ -14,8 +15,9 @@
        ],
       "fields": {
         "service": "<%= ENV['SERVICE_NAME'] || '*' %>",
-        "app": "<%= ENV['APP_NAME'] || '*' %>",
-        "source": "app"
+        "<%= layer %>": "<%= ENV['APP_NAME'] || ENV['DATABASE_NAME'] || '*' %>",
+        "source": "<%= layer %>",
+        "layer": "<%= layer %>"
       }
     },
     {
@@ -26,8 +28,9 @@
        ],
       "fields": {
         "service": "<%= ENV['SERVICE_NAME'] || '*' %>",
-        "app": "<%= ENV['APP_NAME'] || '*' %>",
-        "source": "aptible"
+        "<%= layer %>": "<%= ENV['APP_NAME'] || ENV['DATABASE_NAME'] || '*' %>",
+        "source": "aptible",
+        "layer": "<%= layer %>"
       }
     }
    ]


### PR DESCRIPTION
This adds support for relaying database logs. The changes here are
pretty minimal: we now support DATABASE_NAME in addition to APP_NAME.
This also adds a "layer" property that indicates whether logs came in
via a DB.

To summarize the fields we now have:

- `layer`: can be `app` or `database`. Indicates what type of container
  this log event is for.
- `source`: can be `app`, `database`, or `aptible`. Indicates whether
  this log came from the container itself, or from Aptible (e.g. OOM
  restart).
- `app`: only present when `layer` is `app`. Indicates which app sent
  the logs (app handle).
- `database`: only present when `layer` is `database`. Indicates which
  database sent the logs (database handle).

---

cc @fancyremarker @blakepettersson 