### PR TITLE
Reduce max line size.

### DIFF
--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -70,7 +70,7 @@ processors:
   - truncate_fields:
       fields:
         - json.log
-      max_bytes: 101376
+      max_bytes: 97280
       ignore_missing: true
 
 #============================== Redis output ==================================

--- a/test/joecool.bats
+++ b/test/joecool.bats
@@ -156,7 +156,7 @@ teardown() {
   # line as part of the log line, so we can't just go straight for
   # the full 99KB in just the log message, hence the large, but < 99KB
   # number.
-  random=$(ruby -e "print 'a'*101375")
+  random=$(ruby -e "print 'a'*97279")
   echo $random > /tmp/dockerlogs/bazzz/bazzz-json.log
 
   run timeout -t 10 /bin/bash run-joe-cool.sh
@@ -190,7 +190,7 @@ teardown() {
 
   start_redis
 
-  random=$(ruby -e "print 'a'*101377 + 'b'")
+  random=$(ruby -e "print 'a'*97281 + 'b'")
   echo "{\"log\": \"$random\", \"stream\": \"stdout\"}" > /tmp/dockerlogs/bazz/bazz-json.log
 
   run timeout -t 10 /bin/bash run-joe-cool.sh


### PR DESCRIPTION
Papertrail was dropping some of our log lines because they were too large. Originally the idea was that we would have 99kb logs + 1kb for metadata to be under their 100kb max. This obviously didn't work out (the theory is that metadata is sometimes slightly larger than expected), so this PR is switching to 95kb logs + 5kb for metadata.