### PR TITLE
Fix monitoring multi-container

### DIFF
--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -9,6 +9,7 @@ filebeat.inputs:
   # Below are the input specific configurations.
 
   # TODO: Incorporate TAIL env var to determine where to start in the file
+  <% JSON.parse(ENV['CONTAINERS'] || '[]').each do |container_id| %>
   - type: log
 
     json.keys_under_root: false
@@ -21,7 +22,6 @@ filebeat.inputs:
     enabled: true
 
     # Paths that should be crawled and fetched. Glob based paths.
-    <% JSON.parse(ENV['CONTAINERS'] || '[]').each do |container_id| %>
     paths:
       - /tmp/dockerlogs/<%= container_id %>/<%= container_id %>-json.log
     # Optional additional fields. These fields can be freely picked
@@ -34,8 +34,6 @@ filebeat.inputs:
       container: "<%= container_id %>"
       type: json
 
-    <% end %>
-
   - type: log
 
     json.keys_under_root: false
@@ -48,7 +46,6 @@ filebeat.inputs:
     enabled: true
 
     # Paths that should be crawled and fetched. Glob based paths.
-    <% JSON.parse(ENV['CONTAINERS'] || '[]').each do |container_id| %>
     paths:
       - /tmp/activitylogs/<%= container_id %>-json.log
 


### PR DESCRIPTION
New config:

```
#=========================== Filebeat inputs =============================

filebeat.inputs:

  # Each - is an input. Most options can be set at the input level, so
  # you can use different inputs for various configurations.
  # Below are the input specific configurations.

  # TODO: Incorporate TAIL env var to determine where to start in the file

  - type: log

    json.keys_under_root: false



    # Change to true to enable this input configuration.
    enabled: true

    # Paths that should be crawled and fetched. Glob based paths.
    paths:
      - /tmp/dockerlogs/baz/baz-json.log
    # Optional additional fields. These fields can be freely picked
    # to add additional information to the crawled log files for filtering
    fields_under_root: true
    fields:

      container: "baz"
      type: json

  - type: log

    json.keys_under_root: false



    # Change to true to enable this input configuration.
    enabled: true

    # Paths that should be crawled and fetched. Glob based paths.
    paths:
      - /tmp/activitylogs/baz-json.log

    # Optional additional fields. These fields can be freely picked
    # to add additional information to the crawled log files for filtering
    fields_under_root: true
    fields:

      source: "aptible"
      container: "baz"
      type: json

  - type: log

    json.keys_under_root: false



    # Change to true to enable this input configuration.
    enabled: true

    # Paths that should be crawled and fetched. Glob based paths.
    paths:
      - /tmp/dockerlogs/secondbaz/secondbaz-json.log
    # Optional additional fields. These fields can be freely picked
    # to add additional information to the crawled log files for filtering
    fields_under_root: true
    fields:

      container: "secondbaz"
      type: json

  - type: log

    json.keys_under_root: false



    # Change to true to enable this input configuration.
    enabled: true

    # Paths that should be crawled and fetched. Glob based paths.
    paths:
      - /tmp/activitylogs/secondbaz-json.log

    # Optional additional fields. These fields can be freely picked
    # to add additional information to the crawled log files for filtering
    fields_under_root: true
    fields:

      source: "aptible"
      container: "secondbaz"
      type: json


#================================ Processors =====================================

processors:
  - truncate_fields:
      fields:
        - json.log
      max_bytes: 97280
      ignore_missing: true

#============================== Redis output ==================================

output.redis:
  hosts: ["localhost:6379"]
  password: "foo123"
  key: "filebeat"
  db: 1
  timeout: 15


#================================ Logging =====================================

logging:
  metrics:
    enabled: true
```